### PR TITLE
Content hidden when printing

### DIFF
--- a/dist/css/houdini.css
+++ b/dist/css/houdini.css
@@ -56,3 +56,9 @@
 .houdini-toggle-icon {
   padding: 0 0.5em;
 }
+
+@media print {
+  .houdini-toggle[aria-label] {
+    display: none;
+  }
+}

--- a/dist/css/houdini.min.css
+++ b/dist/css/houdini.min.css
@@ -1,2 +1,2 @@
 /*! houdinijs v11.0.2 | (c) 2019 Chris Ferdinandi | MIT License | http://github.com/cferdinandi/houdini */
-.houdini{display:none}.houdini[tabindex="-1"]:focus{outline:none}.houdini.is-expanded{display:block}@media print{.houdini{display:block}}.houdini-heading .houdini-toggle{background:inherit;border:none;display:block;font:inherit;padding:0;text-align:inherit;width:100%}.houdini-toggle-icon{padding:0 .5em}
+.houdini{display:none}.houdini[tabindex="-1"]:focus{outline:none}.houdini.is-expanded{display:block}@media print{.houdini{display:block}}.houdini-heading .houdini-toggle{background:inherit;border:none;display:block;font:inherit;padding:0;text-align:inherit;width:100%}.houdini-toggle-icon{padding:0 .5em}@media print{.houdini-toggle[aria-label]{display:none}}

--- a/src/sass/houdini.scss
+++ b/src/sass/houdini.scss
@@ -46,3 +46,13 @@
 .houdini-toggle-icon {
 	padding: 0 0.5em;
 }
+
+/**
+ * Hide generated buttons on print view
+ * By using [aria-label] buttons inside a [data-houdini-toggle] won't be hidden
+ */
+.houdini-toggle[aria-label] {
+	@media print {
+		display: none;
+	}
+}


### PR DESCRIPTION
As I was working on a client site today I realised that Houdini content was hidden and only the Houdini buttons were displayed. Because I know you care about displaying content when JS is disabled I figured you'd want the same experience when printing the web.

As a second feature the auto-generated buttons are also hidden on print. The buttons inside `[data-houdini-toggle]` stay visible since they act as headings for the toggled content.

An even better approach would be to make these settings by using SCSS variables so you can easily override compiled output when compiling the styling in your own projects. Let me know if you'd be interested in that so I can create an issue for it and start working on that.