### PR TITLE
Fix typo in preexisting button attribute

### DIFF
--- a/src/js/houdini/houdini.js
+++ b/src/js/houdini/houdini.js
@@ -29,7 +29,7 @@
 		btnAttribute: 'data-houdini-toggle',
 		btnTextAttribute: 'data-houdini-button',
 		btnLabelAttribute: 'data-houdini-label',
-		bntPreexisting: 'data-houdini-button-preexisting',
+		btnPreexisting: 'data-houdini-button-preexisting',
 
 		// Accordion
 		isAccordion: false,


### PR DESCRIPTION
This was causing buttons to have and undefined attribute set, which resulted in `<button undefined="true">`